### PR TITLE
Criar o campo status para a tabela Produto

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,4 +13,7 @@ class Product < ApplicationRecord
   has_many :product_categories, dependent: :destroy
   has_many :categories, through: :product_categories
   has_one_attached :image
+  validates :status, presence: true
+
+  enum status: { available: 1, unavailable: 2 }
 end

--- a/db/migrate/20230724174251_add_status_to_products.rb
+++ b/db/migrate/20230724174251_add_status_to_products.rb
@@ -1,0 +1,5 @@
+class AddStatusToProducts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :products, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_30_202242) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_24_174251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_30_202242) do
     t.bigint "productable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status"
     t.index ["productable_type", "productable_id"], name: "index_products_on_productable_type_and_productable_id"
   end
 

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     description { Faker::Lorem.paragraph }
     price { Faker::Commerce.price(range: 100.0..400.0) }
     image { Rack::Test::UploadedFile.new(Rails.root.join('spec/support/images/product_image.png')) }
+    status { :available }
 
     after :build do |product|
       product.productable = create(:game)

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Product, type: :model do
   it { is_expected.to have_many(:product_categories).dependent(:destroy) }
   it { is_expected.to have_many(:categories).through(:product_categories) }
   it { is_expected.to validate_presence_of(:image) }
+  it { is_expected.to validate_presence_of(:status) }
+  it { is_expected.to define_enum_for(:status).with_values({ available: 1, unavailable: 2 }) }
 
   it_behaves_like 'name searchable concern', :product
   it_behaves_like 'paginatable concern', :product


### PR DESCRIPTION
Esse campo serve para identificar quando um produto estiver disponível ou indisponível para compra.